### PR TITLE
libbpf: update Makefile regarding bpf object building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Dependencies
+*.d
+
 # Directories
-output/
+include/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 	Q = @
 endif
 
-OUTPUTDIR = ./output
+INCDIR = ./include
 
 .PHONY: all
 all: libbpf vmlinuxh bpfobj tests
@@ -34,16 +34,16 @@ CFLAGS = -g -O2 -Werror -Wall -fpie
 
 GIT            = $(shell which git)
 LIBBPFDIR      = $(abspath ./libbpf)
-LIBBPFOBJ      = $(OUTPUTDIR)/libbpf.a
+LIBBPFOBJ      = $(INCDIR)/libbpf.a
 LIBBPFSRCDIR   = $(LIBBPFDIR)/src
 LIBBPFSRCFILES = $(wildcard $(LIBBPFSRCDIR)/*.[ch])
-LIBBPFDESTDIR  = $(abspath $(OUTPUTDIR))
+LIBBPFDESTDIR  = $(abspath $(INCDIR))
 LIBBPFOBJDIR   = $(LIBBPFDESTDIR)/libbpf
 
 .PHONY: libbpf
 libbpf: $(LIBBPFOBJ)
 
-$(LIBBPFOBJ): $(LIBBPFSRCDIR) $(LIBBPFSRCFILES) | $(OUTPUTDIR)
+$(LIBBPFOBJ): $(LIBBPFSRCDIR) $(LIBBPFSRCFILES) | $(INCDIR)
 	$(info INFO: compiling $@)
 	$(Q)CC="$(CC)" CFLAGS="$(CFLAGS)" \
 	$(MAKE) -C $(LIBBPFSRCDIR) \
@@ -65,12 +65,12 @@ endif
 
 BPFTOOL  = $(shell which bpftool)
 BTFFILE  = /sys/kernel/btf/vmlinux
-VMLINUXH = $(OUTPUTDIR)/vmlinux.h
+VMLINUXH = $(INCDIR)/vmlinux.h
 
 .PHONY: vmlinuxh
 vmlinuxh: $(VMLINUXH)
 
-$(VMLINUXH): $(BTFFILE) | $(OUTPUTDIR)
+$(VMLINUXH): $(BTFFILE) | $(INCDIR)
 	$(info INFO: generating $@ from $<)
 	$(Q)$(BPFTOOL) btf dump file $< format c > $@;
 
@@ -83,14 +83,17 @@ endif
 # bpf objects
 
 CLANG      = clang
-CLANGFLAGS = -g -O2 -c -target bpf
-CLANGINC   = $(OUTPUTDIR)
+CLANGFLAGS = -g -O2 -c -target bpf -MMD -MP
+CLANGINC   = $(INCDIR)
 BPFOBJDIR  = $(abspath ./tests)
 BPFS_C     = $(wildcard $(BPFOBJDIR)/*.bpf.c)
 BPFS_O     = $(BPFS_C:.c=.o)
+BPFS_D     = $(patsubst %.o,%.d,$(BPFS_O))
 
 .PHONY: bpfobj
 bpfobj: libbpf vmlinuxh $(BPFS_O)
+
+-include $(BPFS_D)
 
 $(BPFOBJDIR)/%.o: $(BPFOBJDIR)/%.c
 	$(info INFO: compiling bpf object $@)
@@ -124,11 +127,11 @@ run-tests: $(TESTS)
 
 # output
 
-$(OUTPUTDIR):
+$(INCDIR):
 	$(Q)mkdir -p $@
 
 
 # cleanup
 
 clean:
-	$(Q)rm -rf $(OUTPUTDIR) $(BPFS_O) $(TESTS)
+	$(Q)rm -rf $(INCDIR) $(BPFS_O) $(BPFS_D) $(TESTS)


### PR DESCRIPTION
This changes the intermediary folder name from 'output' to 'include' and introduces .d creation.

This also updates `.gitignore`.