### PR TITLE
Fix issues #7 and #8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INCDIR = ./include
 all: libbpf vmlinuxh bpfobj tests
 
 
-# libbpf
+# C libbpf
 
 CC     = gcc
 CFLAGS = -g -O2 -Werror -Wall -fpie
@@ -109,7 +109,7 @@ TESTS    = $(TESTS_GO:.go=)
 .PHONY: tests
 tests: bpfobj $(TESTS)
 
-$(TESTS): % : %.go | bpfobj
+$(TESTS): % : %.go
 	$(info INFO: compiling test $@)
 	$(Q)CGO_LDFLAGS=$(LIBBPFOBJ) \
 		go build -o $@ $^
@@ -125,7 +125,7 @@ run-tests: $(TESTS)
 	done
 
 
-# output
+# intermediary output
 
 $(INCDIR):
 	$(Q)mkdir -p $@

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kubearmor/libbpf
 
 go 1.16
 
-require github.com/aquasecurity/libbpfgo v0.1.2-0.20210728125149-cd17c665a141
+require (
+	github.com/aquasecurity/libbpfgo v0.1.2-0.20210728125149-cd17c665a141
+	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/libbpf.go
+++ b/libbpf.go
@@ -16,6 +16,7 @@ type KABPFObject struct {
 
 // KubeArmor BPFMap wrapper structure
 type KABPFMap struct {
+	bpfObj *KABPFObject
 	bpfMap *libbpfgo.BPFMap
 }
 
@@ -43,6 +44,7 @@ func (o *KABPFObject) FindMapByName(mapName string) (*KABPFMap, error) {
 	m, err := o.bpfObj.GetMap(mapName)
 
 	return &KABPFMap{
+		bpfObj: o,
 		bpfMap: m,
 	}, err
 }
@@ -119,7 +121,5 @@ func (m *KABPFMap) DeleteElement(key unsafe.Pointer) error {
 
 // Get object pointer to which map belongs
 func (m *KABPFMap) Object() *KABPFObject {
-	return &KABPFObject{
-		bpfObj: m.bpfMap.GetModule(),
-	}
+	return m.bpfObj
 }

--- a/libbpf.go
+++ b/libbpf.go
@@ -7,6 +7,45 @@ import (
 	"unsafe"
 
 	"github.com/aquasecurity/libbpfgo"
+	unix "golang.org/x/sys/unix"
+)
+
+import "C"
+
+type KABPFProgType uint32
+
+const (
+	KABPFProgTypeUnspec                KABPFProgType = unix.BPF_PROG_TYPE_UNSPEC
+	KABPFProgTypeSocketFilter                        = unix.BPF_PROG_TYPE_SOCKET_FILTER
+	KABPFProgTypeKprobe                              = unix.BPF_PROG_TYPE_KPROBE
+	KABPFProgTypeSchedCls                            = unix.BPF_PROG_TYPE_SCHED_CLS
+	KABPFProgTypeSchedAct                            = unix.BPF_PROG_TYPE_SCHED_ACT
+	KABPFProgTypeTracepoint                          = unix.BPF_PROG_TYPE_TRACEPOINT
+	KABPFProgTypeXDP                                 = unix.BPF_PROG_TYPE_XDP
+	KABPFProgTypePerfEvent                           = unix.BPF_PROG_TYPE_PERF_EVENT
+	KABPFProgTypeCgroupSKB                           = unix.BPF_PROG_TYPE_CGROUP_SKB
+	KABPFProgTypeCgroupSock                          = unix.BPF_PROG_TYPE_CGROUP_SOCK
+	KABPFProgTypeLwtIn                               = unix.BPF_PROG_TYPE_LWT_IN
+	KABPFProgTypeLwtOut                              = unix.BPF_PROG_TYPE_LWT_OUT
+	KABPFProgTypeLwtXmit                             = unix.BPF_PROG_TYPE_LWT_XMIT
+	KABPFProgTypeSockOps                             = unix.BPF_PROG_TYPE_SOCK_OPS
+	KABPFProgTypeSkSKB                               = unix.BPF_PROG_TYPE_SK_SKB
+	KABPFProgTypeCgroupDevice                        = unix.BPF_PROG_TYPE_CGROUP_DEVICE
+	KABPFProgTypeSkMsg                               = unix.BPF_PROG_TYPE_SK_MSG
+	KABPFProgTypeRawTracepoint                       = unix.BPF_PROG_TYPE_RAW_TRACEPOINT
+	KABPFProgTypeCgroupSockAddr                      = unix.BPF_PROG_TYPE_CGROUP_SOCK_ADDR
+	KABPFProgTypeLwtSeg6Local                        = unix.BPF_PROG_TYPE_LWT_SEG6LOCAL
+	KABPFProgTypeLircMode2                           = unix.BPF_PROG_TYPE_LIRC_MODE2
+	KABPFProgTypeSkReuseport                         = unix.BPF_PROG_TYPE_SK_REUSEPORT
+	KABPFProgTypeFlowDissector                       = unix.BPF_PROG_TYPE_FLOW_DISSECTOR
+	KABPFProgTypeCgroupSysctl                        = unix.BPF_PROG_TYPE_CGROUP_SYSCTL
+	KABPFProgTypeRawTracepointWritable               = unix.BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
+	KABPFProgTypeCgroupSockopt                       = unix.BPF_PROG_TYPE_CGROUP_SOCKOPT
+	KABPFProgTypeTracing                             = unix.BPF_PROG_TYPE_TRACING
+	KABPFProgTypeStructOps                           = unix.BPF_PROG_TYPE_STRUCT_OPS
+	KABPFProgTypeExt                                 = unix.BPF_PROG_TYPE_EXT
+	KABPFProgTypeLSM                                 = unix.BPF_PROG_TYPE_LSM
+	KABPFProgTypeSkLookup                            = unix.BPF_PROG_TYPE_SK_LOOKUP
 )
 
 // KubeArmor BPFObject wrapper structure
@@ -18,6 +57,19 @@ type KABPFObject struct {
 type KABPFMap struct {
 	bpfObj *KABPFObject
 	bpfMap *libbpfgo.BPFMap
+}
+
+// KubeArmor BPFProgram wrapper structure
+type KABPFProgram struct {
+	bpfObj  *KABPFObject
+	bpfProg *libbpfgo.BPFProg
+}
+
+// KubeArmor BPFLink wrapper structure
+type KABPFLink struct {
+	bpfProg  *KABPFProgram
+	funcName string
+	bpfLink  *libbpfgo.BPFLink
 }
 
 // Open object file
@@ -46,6 +98,16 @@ func (o *KABPFObject) FindMapByName(mapName string) (*KABPFMap, error) {
 	return &KABPFMap{
 		bpfObj: o,
 		bpfMap: m,
+	}, err
+}
+
+// Get program from object
+func (o *KABPFObject) FindProgramByName(progName string) (*KABPFProgram, error) {
+	p, err := o.bpfObj.GetProgram(progName)
+
+	return &KABPFProgram{
+		bpfObj:  o,
+		bpfProg: p,
 	}, err
 }
 
@@ -122,4 +184,58 @@ func (m *KABPFMap) DeleteElement(key unsafe.Pointer) error {
 // Get object pointer to which map belongs
 func (m *KABPFMap) Object() *KABPFObject {
 	return m.bpfObj
+}
+
+// Get program fd
+func (p *KABPFProgram) FD() int {
+	return int(p.bpfProg.GetFd())
+}
+
+// Get program name
+func (p *KABPFProgram) Name() string {
+	return p.bpfProg.GetName()
+}
+
+// Get program type
+func (p *KABPFProgram) GetType() KABPFProgType {
+	return KABPFProgType(p.bpfProg.GetType())
+}
+
+// Attach Kprobe
+// This should be used for kernels > 4.17
+func (p *KABPFProgram) AttachKprobe(funcName string) (*KABPFLink, error) {
+	l, err := p.bpfProg.AttachKprobe(funcName)
+
+	return &KABPFLink{
+		bpfProg:  p,
+		funcName: funcName,
+		bpfLink:  l,
+	}, err
+}
+
+// Attach Kretprobe
+// This should be used for kernels > 4.17
+func (p *KABPFProgram) AttachKretprobe(funcName string) (*KABPFLink, error) {
+	l, err := p.bpfProg.AttachKretprobe(funcName)
+
+	return &KABPFLink{
+		bpfProg:  p,
+		funcName: funcName,
+		bpfLink:  l,
+	}, err
+}
+
+// Get object pointer to which program belongs
+func (p *KABPFProgram) Object() *KABPFObject {
+	return p.bpfObj
+}
+
+// Get attached function name
+func (l *KABPFLink) FunctionName() string {
+	return l.funcName
+}
+
+// Get program pointer to which link belongs
+func (l *KABPFLink) Program() *KABPFProgram {
+	return l.bpfProg
 }

--- a/libbpf.go
+++ b/libbpf.go
@@ -56,12 +56,14 @@ type KABPFObject struct {
 // KubeArmor BPFMap wrapper structure
 type KABPFMap struct {
 	bpfObj *KABPFObject
+
 	bpfMap *libbpfgo.BPFMap
 }
 
 // KubeArmor BPFProgram wrapper structure
 type KABPFProgram struct {
-	bpfObj  *KABPFObject
+	bpfObj *KABPFObject
+
 	bpfProg *libbpfgo.BPFProg
 }
 
@@ -69,7 +71,8 @@ type KABPFProgram struct {
 type KABPFLink struct {
 	bpfProg  *KABPFProgram
 	funcName string
-	bpfLink  *libbpfgo.BPFLink
+
+	bpfLink *libbpfgo.BPFLink
 }
 
 // Open object file

--- a/tests/maps.go
+++ b/tests/maps.go
@@ -25,6 +25,7 @@ func exitIfError(err error) {
 // Print map information
 func printMapInfo(m *lbpf.KABPFMap) {
 	fmt.Println()
+	fmt.Println("Map Object:     ", unsafe.Pointer(m.Object()))
 	fmt.Println("Map Name:       ", m.Name())
 	fmt.Println("Map FD:         ", m.FD())
 	fmt.Println("Map Pinned:     ", m.IsPinned())


### PR DESCRIPTION
Fixing #7, this introduces:

- `KABPFProgType` enum
- `KABPFProgram` structure and basic methods
- `KABPFLink` structure and basic methods

The `KABPFObject.Close()` method has not been touched regarding links cleanup, as the wrapped library (libbpfgo) already takes care of that.

This fixes #8:

- Wrong reference returned by `KABPFMap.Object()`

This also does some cleanup.