### PR TITLE
libbpf: API change: KABPFMapElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,29 @@ The same environment variable need to be set when building the final application
 The use cases inside `./tests` can be tested using make.
 
 `❯ make run-tests`
+
+---
+
+### KABPFMapElement interface
+
+To satisfy `KABPFMapElement` interface, it's necessary to implement the following methods for an XXMapElem.
+
+```go
+func (pme *XXMapElem) KeyPointer() unsafe.Pointer {
+	...
+}
+
+func (pme *XXMapElem) ValuePointer() unsafe.Pointer {
+	...
+}
+
+func (pme *XXMapElem) SetFoundValue(value []byte) {
+	...
+}
+
+func (pme *XXMapElem) MapName() string {
+	return "map_name"
+}
+```
+
+Examples can be found in [tests](tests/).

--- a/libbpf.go
+++ b/libbpf.go
@@ -64,7 +64,9 @@ type KABPFMap struct {
 type KABPFMapElement interface {
 	KeyPointer() unsafe.Pointer
 	ValuePointer() unsafe.Pointer
-	SetValue(value []byte)
+	MapName() string
+
+	SetFoundValue(value []byte)
 }
 
 // KubeArmor BPFProgram wrapper structure
@@ -189,7 +191,7 @@ func (m *KABPFMap) ValueSize() int {
 // The elem will have its value updated
 func (m *KABPFMap) LookupElement(elem KABPFMapElement) ([]byte, error) {
 	val, err := m.bpfMap.GetValue(elem.KeyPointer())
-	elem.SetValue(val)
+	elem.SetFoundValue(val)
 
 	return val, err
 }

--- a/tests/maps.go
+++ b/tests/maps.go
@@ -31,8 +31,13 @@ func (pme *PinnedMapElem) ValuePointer() unsafe.Pointer {
 }
 
 // Method to satisfy KABPFMapElement interface
-func (pme *PinnedMapElem) SetValue(value []byte) {
+func (pme *PinnedMapElem) SetFoundValue(value []byte) {
 	pme.Value = binary.LittleEndian.Uint32(value)
+}
+
+// Method to satisfy KABPFMapElement interface
+func (pme *PinnedMapElem) MapName() string {
+	return "pinned_map"
 }
 
 // Exit if err is not nil
@@ -57,6 +62,15 @@ func printMapInfo(m *lbpf.KABPFMap) {
 	fmt.Println("Map Max Entries:", m.MaxEntries())
 }
 
+// Print map element information
+func printMapElemInfo(me lbpf.KABPFMapElement) {
+	fmt.Println()
+	fmt.Println("Map Name:         ", me.MapName())
+	fmt.Println("Map Key Pointer:  ", me.KeyPointer())
+	fmt.Println("Map Value Pointer:", me.ValuePointer())
+	fmt.Println()
+}
+
 // Test map element management
 func testPinnedMapElementManagement(m *lbpf.KABPFMap) {
 	var err error
@@ -65,6 +79,8 @@ func testPinnedMapElementManagement(m *lbpf.KABPFMap) {
 
 	fmt.Println()
 	fmt.Println("Testing element management methods: started")
+
+	printMapElemInfo(&pme)
 
 	pme.Key = 0
 	pme.Value = 1337


### PR DESCRIPTION
This renames the method `SetValue()` to `SetFoundValue()` making its purpose
evident: to be called after `LookupElement()` to update the `KABPFMapElement` value.

This also adds `MapName()` getter for consumer use.