### PR TITLE
Updates and Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ However, currently, the most common is to use the `libbpf.a` (static version). T
 
   This will generate the static `libbpf.a` file and the `vmlinux.h` and `bpf/*.h` headers inside `./include`.
 
-- Now one is able to make correct use of this library.
+- Now one is able to make correct use of this library. Be sure to use absolute paths.
 
-  `❯ CGO_LDFLAGS="./include/libbpf.a" go get github.com/kubearmor/libbpf`
+  `❯ CGO_LDFLAGS="/path_to_this_repo/include/libbpf.a" CGO_CFLAGS="-I /path_to_this_repo/include" go get github.com/kubearmor/libbpf`
 
 The same environment variable need to be set when building the final application that uses this library.
 
-`❯ CGO_LDFLAGS="./include/libbpf.a" go build`
+`❯ CGO_LDFLAGS="/path_to_this_repo/include/libbpf.a" CGO_CFLAGS="-I /path_to_this_repo/include" go build`
 
 ---
 
-The use cases inside `./tests` can be tested using make.
+The use cases inside [tests](tests/) can be tested using make.
 
 `❯ make run-tests`
 
@@ -76,4 +76,4 @@ func (pme *XXMapElem) MapName() string {
 }
 ```
 
-Examples can be found in [tests](tests/).
+Examples can also be found in [tests](tests/).

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/kubearmor/libbpf
 go 1.16
 
 require (
-	github.com/aquasecurity/libbpfgo v0.1.2-0.20210728125149-cd17c665a141
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275
+	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210728125149-cd17c665a141 h1:RhQCgmmomHgiJ51lCBt3RhuZEURZa3W9h2z3apVjGos=
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210728125149-cd17c665a141/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275 h1:HL5pK6Qn+C2NVasqbUv3V1FxjeSX7lZ52pmYZaVgKFA=
+github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -7,7 +7,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/libbpf.go
+++ b/libbpf.go
@@ -217,7 +217,7 @@ func (m *KABPFMap) Object() *KABPFObject {
 
 // Get program fd
 func (p *KABPFProgram) FD() int {
-	return int(p.bpfProg.GetFd())
+	return p.bpfProg.GetFd()
 }
 
 // Get program name

--- a/libbpf.go
+++ b/libbpf.go
@@ -16,36 +16,36 @@ type KABPFProgType uint32
 
 const (
 	KABPFProgTypeUnspec                KABPFProgType = unix.BPF_PROG_TYPE_UNSPEC
-	KABPFProgTypeSocketFilter                        = unix.BPF_PROG_TYPE_SOCKET_FILTER
-	KABPFProgTypeKprobe                              = unix.BPF_PROG_TYPE_KPROBE
-	KABPFProgTypeSchedCls                            = unix.BPF_PROG_TYPE_SCHED_CLS
-	KABPFProgTypeSchedAct                            = unix.BPF_PROG_TYPE_SCHED_ACT
-	KABPFProgTypeTracepoint                          = unix.BPF_PROG_TYPE_TRACEPOINT
-	KABPFProgTypeXDP                                 = unix.BPF_PROG_TYPE_XDP
-	KABPFProgTypePerfEvent                           = unix.BPF_PROG_TYPE_PERF_EVENT
-	KABPFProgTypeCgroupSKB                           = unix.BPF_PROG_TYPE_CGROUP_SKB
-	KABPFProgTypeCgroupSock                          = unix.BPF_PROG_TYPE_CGROUP_SOCK
-	KABPFProgTypeLwtIn                               = unix.BPF_PROG_TYPE_LWT_IN
-	KABPFProgTypeLwtOut                              = unix.BPF_PROG_TYPE_LWT_OUT
-	KABPFProgTypeLwtXmit                             = unix.BPF_PROG_TYPE_LWT_XMIT
-	KABPFProgTypeSockOps                             = unix.BPF_PROG_TYPE_SOCK_OPS
-	KABPFProgTypeSkSKB                               = unix.BPF_PROG_TYPE_SK_SKB
-	KABPFProgTypeCgroupDevice                        = unix.BPF_PROG_TYPE_CGROUP_DEVICE
-	KABPFProgTypeSkMsg                               = unix.BPF_PROG_TYPE_SK_MSG
-	KABPFProgTypeRawTracepoint                       = unix.BPF_PROG_TYPE_RAW_TRACEPOINT
-	KABPFProgTypeCgroupSockAddr                      = unix.BPF_PROG_TYPE_CGROUP_SOCK_ADDR
-	KABPFProgTypeLwtSeg6Local                        = unix.BPF_PROG_TYPE_LWT_SEG6LOCAL
-	KABPFProgTypeLircMode2                           = unix.BPF_PROG_TYPE_LIRC_MODE2
-	KABPFProgTypeSkReuseport                         = unix.BPF_PROG_TYPE_SK_REUSEPORT
-	KABPFProgTypeFlowDissector                       = unix.BPF_PROG_TYPE_FLOW_DISSECTOR
-	KABPFProgTypeCgroupSysctl                        = unix.BPF_PROG_TYPE_CGROUP_SYSCTL
-	KABPFProgTypeRawTracepointWritable               = unix.BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
-	KABPFProgTypeCgroupSockopt                       = unix.BPF_PROG_TYPE_CGROUP_SOCKOPT
-	KABPFProgTypeTracing                             = unix.BPF_PROG_TYPE_TRACING
-	KABPFProgTypeStructOps                           = unix.BPF_PROG_TYPE_STRUCT_OPS
-	KABPFProgTypeExt                                 = unix.BPF_PROG_TYPE_EXT
-	KABPFProgTypeLSM                                 = unix.BPF_PROG_TYPE_LSM
-	KABPFProgTypeSkLookup                            = unix.BPF_PROG_TYPE_SK_LOOKUP
+	KABPFProgTypeSocketFilter          KABPFProgType = unix.BPF_PROG_TYPE_SOCKET_FILTER
+	KABPFProgTypeKprobe                KABPFProgType = unix.BPF_PROG_TYPE_KPROBE
+	KABPFProgTypeSchedCls              KABPFProgType = unix.BPF_PROG_TYPE_SCHED_CLS
+	KABPFProgTypeSchedAct              KABPFProgType = unix.BPF_PROG_TYPE_SCHED_ACT
+	KABPFProgTypeTracepoint            KABPFProgType = unix.BPF_PROG_TYPE_TRACEPOINT
+	KABPFProgTypeXDP                   KABPFProgType = unix.BPF_PROG_TYPE_XDP
+	KABPFProgTypePerfEvent             KABPFProgType = unix.BPF_PROG_TYPE_PERF_EVENT
+	KABPFProgTypeCgroupSKB             KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_SKB
+	KABPFProgTypeCgroupSock            KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_SOCK
+	KABPFProgTypeLwtIn                 KABPFProgType = unix.BPF_PROG_TYPE_LWT_IN
+	KABPFProgTypeLwtOut                KABPFProgType = unix.BPF_PROG_TYPE_LWT_OUT
+	KABPFProgTypeLwtXmit               KABPFProgType = unix.BPF_PROG_TYPE_LWT_XMIT
+	KABPFProgTypeSockOps               KABPFProgType = unix.BPF_PROG_TYPE_SOCK_OPS
+	KABPFProgTypeSkSKB                 KABPFProgType = unix.BPF_PROG_TYPE_SK_SKB
+	KABPFProgTypeCgroupDevice          KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_DEVICE
+	KABPFProgTypeSkMsg                 KABPFProgType = unix.BPF_PROG_TYPE_SK_MSG
+	KABPFProgTypeRawTracepoint         KABPFProgType = unix.BPF_PROG_TYPE_RAW_TRACEPOINT
+	KABPFProgTypeCgroupSockAddr        KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_SOCK_ADDR
+	KABPFProgTypeLwtSeg6Local          KABPFProgType = unix.BPF_PROG_TYPE_LWT_SEG6LOCAL
+	KABPFProgTypeLircMode2             KABPFProgType = unix.BPF_PROG_TYPE_LIRC_MODE2
+	KABPFProgTypeSkReuseport           KABPFProgType = unix.BPF_PROG_TYPE_SK_REUSEPORT
+	KABPFProgTypeFlowDissector         KABPFProgType = unix.BPF_PROG_TYPE_FLOW_DISSECTOR
+	KABPFProgTypeCgroupSysctl          KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_SYSCTL
+	KABPFProgTypeRawTracepointWritable KABPFProgType = unix.BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
+	KABPFProgTypeCgroupSockopt         KABPFProgType = unix.BPF_PROG_TYPE_CGROUP_SOCKOPT
+	KABPFProgTypeTracing               KABPFProgType = unix.BPF_PROG_TYPE_TRACING
+	KABPFProgTypeStructOps             KABPFProgType = unix.BPF_PROG_TYPE_STRUCT_OPS
+	KABPFProgTypeExt                   KABPFProgType = unix.BPF_PROG_TYPE_EXT
+	KABPFProgTypeLSM                   KABPFProgType = unix.BPF_PROG_TYPE_LSM
+	KABPFProgTypeSkLookup              KABPFProgType = unix.BPF_PROG_TYPE_SK_LOOKUP
 )
 
 // KubeArmor BPFObject wrapper structure


### PR DESCRIPTION
- sub-module updated (C libbpf)
- remove conversion following the libbpfgo update (https://github.com/aquasecurity/libbpfgo/commit/0438957b8472726d59411e8b5ffa67fca580f8cd)
- fix constants definition type (KABPFProgType)
- update/enhance instructions (README.md)