### PR TITLE
libbpf: add an empty Detach method to KABPFLink

### DIFF
--- a/libbpf.go
+++ b/libbpf.go
@@ -274,3 +274,8 @@ func (l *KABPFLink) FunctionName() string {
 func (l *KABPFLink) Program() *KABPFProgram {
 	return l.bpfProg
 }
+
+// Detach link
+func (l *KABPFLink) Detach() error {
+	return nil
+}


### PR DESCRIPTION
This empty method is a WIP -> aquasecurity/libbpfgo#66