### PR TITLE
libbpf: update go.mod go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/kubearmor/libbpf
 go 1.16
 
 require (
-	github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275
+	github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275 h1:HL5pK6Qn+C2NVasqbUv3V1FxjeSX7lZ52pmYZaVgKFA=
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210829014248-7b3863382275/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c h1:MZdKpQb3jqE0q6zWS2nt1/ZAvKAML3PvSOeifi1UQ9w=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/libbpf.go
+++ b/libbpf.go
@@ -309,8 +309,8 @@ func (p *KABPFProgram) AttachRawTracepoint(eventName string) (*KABPFLink, error)
 }
 
 // Attach Tracepoint
-func (p *KABPFProgram) AttachTracepoint(eventName string) (*KABPFLink, error) {
-	l, err := p.bpfProg.AttachTracepoint(eventName)
+func (p *KABPFProgram) AttachTracepoint(category, eventName string) (*KABPFLink, error) {
+	l, err := p.bpfProg.AttachTracepoint(category, eventName)
 	if err != nil {
 		return nil, err
 	}

--- a/libbpf.go
+++ b/libbpf.go
@@ -343,7 +343,7 @@ func (l *KABPFLink) Program() *KABPFProgram {
 	return l.bpfProg
 }
 
-// Detach link
-func (l *KABPFLink) Detach() error {
-	return nil
+// Destroy link
+func (l *KABPFLink) Destroy() error {
+	return l.bpfLink.Destroy()
 }


### PR DESCRIPTION
This changes `AttachTracepoint()` signature accordingly libbpf API - **breaks things**.

This also fixes #18 replacing `Detach()` with `Destroy()` for KABPFLink.