### PR TITLE
libbpf: update go.mod go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/kubearmor/libbpf
 go 1.16
 
 require (
-	github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c
+	github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c h1:MZdKpQb3jqE0q6zWS2nt1/ZAvKAML3PvSOeifi1UQ9w=
-github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928124427-df4987ad001c/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12 h1:QLp21PoE/3ScbhcdZsmu3EoR01JTp8uEoPn4F1wd3Kc=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
The initializer was implemented for `KABPFObject` and `KABPFMap`:

```
KABPFObject.InitRingBuf(mapName string, eventsChan chan []byte)
KABPFMap.InitRingBuf(eventsChan chan []byte)
```

They follow the same logic, the magic will be done calling any one of them.

For `KABPFRingBuffer` there are functions for the data polling control:

`StartPoll()`, `StopPoll()`

And to release the ring buffer there is `Free()`.

The related map to the `KABPFRingBuffer` can be accessed by `Map()`.

This PR also updates go.mod.

Fixes: #24