### PR TITLE
libbpf: add comment

### DIFF
--- a/libbpf.go
+++ b/libbpf.go
@@ -100,7 +100,7 @@ type KABPFLink struct {
 	bpfLink *libbpfgo.BPFLink
 }
 
-//
+// KubeArmor RingBuffer wrapper structure
 type KABPFRingBuffer struct {
 	bpfMap *KABPFMap
 

--- a/libbpf.go
+++ b/libbpf.go
@@ -107,6 +107,13 @@ type KABPFRingBuffer struct {
 	bpfRingBuffer *libbpfgo.RingBuffer
 }
 
+// KubeArmor PerfBuffer wrapper structure
+type KABPFPerfBuffer struct {
+	bpfMap *KABPFMap
+
+	bpfPerfBuffer *libbpfgo.PerfBuffer
+}
+
 // Open object file
 func OpenObjectFromFile(bpfObjFile string) (*KABPFObject, error) {
 	mod, err := libbpfgo.NewModuleFromFile(bpfObjFile)
@@ -175,6 +182,29 @@ func (o *KABPFObject) InitRingBuf(mapName string, eventsChan chan []byte) (*KABP
 	return &KABPFRingBuffer{
 		bpfMap:        m,
 		bpfRingBuffer: rb,
+	}, nil
+}
+
+// Initialize perf buffer
+func (o *KABPFObject) InitPerfBuf(mapName string, eventsChan chan []byte, lostChan chan uint64, pageCnt int) (*KABPFPerfBuffer, error) {
+	var err error
+	var m *KABPFMap
+
+	m, err = o.FindMapByName(mapName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pb *libbpfgo.PerfBuffer
+
+	pb, err = o.bpfObj.InitPerfBuf(m.Name(), eventsChan, lostChan, pageCnt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KABPFPerfBuffer{
+		bpfMap:        m,
+		bpfPerfBuffer: pb,
 	}, nil
 }
 
@@ -264,6 +294,11 @@ func (m *KABPFMap) Object() *KABPFObject {
 // Initialize ring buffer
 func (m *KABPFMap) InitRingBuf(eventsChan chan []byte) (*KABPFRingBuffer, error) {
 	return m.bpfObj.InitRingBuf(m.Name(), eventsChan)
+}
+
+// Initialize perf buffer
+func (m *KABPFMap) InitPerfBuf(eventsChan chan []byte, lostChan chan uint64, pageCnt int) (*KABPFPerfBuffer, error) {
+	return m.bpfObj.InitPerfBuf(m.Name(), eventsChan, lostChan, pageCnt)
 }
 
 // Get program fd
@@ -401,4 +436,24 @@ func (rb *KABPFRingBuffer) Free() {
 // Get map pointer to which ring buffer relates
 func (rb *KABPFRingBuffer) Map() *KABPFMap {
 	return rb.bpfMap
+}
+
+// Start to poll perf buffer
+func (pb *KABPFPerfBuffer) StartPoll() {
+	pb.bpfPerfBuffer.Start()
+}
+
+// Stop to poll perf buffer
+func (pb *KABPFPerfBuffer) StopPoll() {
+	pb.bpfPerfBuffer.Stop()
+}
+
+// Free perf buffer
+func (pb *KABPFPerfBuffer) Free() {
+	pb.bpfPerfBuffer.Close()
+}
+
+// Get map pointer to which perf buffer relates
+func (pb *KABPFPerfBuffer) Map() *KABPFMap {
+	return pb.bpfMap
 }


### PR DESCRIPTION
The initializer was implemented for `KABPFObject` and `KABPFMap`:

`KABPFObject.InitPerfBuf(mapName string, eventsChan chan []byte, lostChan chan uint64, pageCnt int)`
`KABPFMap.InitPerfBuf(eventsChan chan []byte, lostChan chan uint64, pageCnt int)`

They follow the same logic, the magic will be done calling any one of them.

For `KABPFPerfBuffer` there are functions for the data polling control:

`StartPoll()`, `StopPoll()`

And to release the perf buffer there is `Free()`.

The related map to the `KABPFPerfBuffer` can be accessed by `Map()`.

Fixes: #26